### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-sanity-studio.yml
+++ b/.github/workflows/deploy-sanity-studio.yml
@@ -1,4 +1,6 @@
 name: Deploy Sanity Studio
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/petterdaae/daae.dev/security/code-scanning/2](https://github.com/petterdaae/daae.dev/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since the workflow involves checking out code and deploying using a secret token, the `contents: read` permission is sufficient. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, and no unnecessary write permissions are granted.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
